### PR TITLE
feat(frontend): Implement WebSocket client

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,13 @@ import { useState, useEffect } from 'react'
 import './App.css';
 
 function App() {
+  // State for the /api/hello messge
   const [message, setMessage] = useState('Loading message from Go...');
+
+  // State for messages from the WebSocket
+  const [assessment, setAssessment] = useState("No assessment result yet.")
+
+  // useEffect handles the initial "hello" fetch.
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -25,11 +31,43 @@ function App() {
     fetchData();
   }, []);
 
+  // useEffect handles the WebSocket connection.
+  useEffect(() => {
+    // Create a WebSocket connection
+    const ws = new WebSocket('ws://localhost:8080/ws');
+
+    // Set up event listeners
+    ws.onopen = () => {
+      console.log('WebSocket connection established.');
+    };
+
+    ws.onmessage = (event) => {
+      setAssessment(event.data)
+    };
+
+    ws.onclose = () => {
+      console.log('WebSocket connection closed.');
+    };
+
+    ws.onerror = (error) => {
+      console.error('WebSocket error:', error);
+    };
+
+    // Clean up the connection when the component unmounts
+    return () => {
+      ws.close();
+    };
+  }, []);
+
   return (
     <div>
       <h1>Yobitsugi App</h1>
       <p>
         <strong>Message from Go:</strong> {message}
+      </p>
+
+      <p>
+        <strong>Real-time Assessment (WS):</strong> {assessment}
       </p>
     </div>
   );


### PR DESCRIPTION
Closes #13

## Summary
Updates the React app to establish a persistent WebSocket connection to the Go BFF's `/ws` endpoint. This sets up the real-time communication channel to receive assessment results.

## Key Changes
* **`frontend/src/App.tsx`:**
    * Added a new `useState` variable (`assessment`) to store messages from the WebSocket.
    * Added a new `useEffect` hook that runs once on component mount.
    * Inside the `useEffect`, it creates a `new WebSocket('ws://localhost:8080/ws')`.
    * Implemented `onopen`, `onmessage`, `onclose`, and `onerror` event listeners.
    * The `onmessage` listener updates the `assessment` state with the data received.
    * Added a cleanup function in `useEffect` to close the connection when the component unmounts.
    * Rendered the `assessment` state on the page.

## How to Verify
This verifies that the React client can successfully connect to the Go Hub from Issue #12.

1.  Check out this branch.
2.  In **Terminal 1**, run the Go BFF:
    ```bash
    cd bff
    go run main.go hub.go
    ```
3.  In **Terminal 2**, run the React app:
    ```bash
    cd frontend
    npm run dev
    ```
4.  Open the React app in your browser (e.g., `http://localhost:5173`).
5.  **Expected Result (Go Terminal):** The Go server log should print:
    `Client successfully upgraded to WebSocket`
    `A new client has connected. Total clients: 1`
6.  **Expected Result (Browser):** The React page should display:
    * **Message from Go (API):** Hello from Go BFF! 🚀 (Now with Gin!)
    * **Real-time Assessment (WS):** No assessment result yet.