### PR TITLE
refactor(bff): Migrate GORM from SQLite to PostgreSQL

### DIFF
--- a/bff/database.go
+++ b/bff/database.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"gorm.io/driver/postgres" // <-- ADD Postgres driver
 	"gorm.io/driver/sqlite"   // <-- Keep SQLite driver
@@ -31,8 +32,8 @@ func InitDatabase() *gorm.DB {
 	var err error
 
 	dsn := os.Getenv("DATABASE_URL")
-	if dsn != "" {
-		log.Println("DATABASE_URL not set, failling back to SQLite.")
+	if dsn == "" {
+		log.Println("DATABASE_URL not set, falling back to SQLite.")
 		db, err = gorm.Open(sqlite.Open("yobitsugi.db"), &gorm.Config{})
 		if err != nil {
 			log.Fatal("Failed to connect to SQLite database:", err)
@@ -44,8 +45,7 @@ func InitDatabase() *gorm.DB {
 		if err != nil {
 			log.Fatal("Failed to connect to PostgreSQL database:", err)
 		}
-		log.Println("PostgreSQL database connection established.")
-	}	
+	}
 
 	log.Println("Running database auto-migration...")
 	if err := db.AutoMigrate(&AssessmentJob{}); err != nil {

--- a/bff/database.go
+++ b/bff/database.go
@@ -3,7 +3,8 @@ package main
 import (
 	"log"
 
-	"gorm.io/driver/sqlite"
+	"gorm.io/driver/postgres" // <-- ADD Postgres driver
+	"gorm.io/driver/sqlite"   // <-- Keep SQLite driver
 	"gorm.io/gorm"
 )
 
@@ -11,8 +12,8 @@ import (
 type AssessmentJob struct {
 	gorm.Model
 	
-	ClientID string `gorm:"index"`
-	Status 	 string // "PENDING", "COMPLETE", "ERROR"
+	ClientID 		string `gorm:"index"`
+	Status 	 		string // "PENDING", "COMPLETE", "ERROR"
 	
 	OriginalCode	string
 	PatchedCode 	string
@@ -26,12 +27,25 @@ type AssessmentJob struct {
 
 // InitDatabase initializes the SQLite database connection and runs AutoMigrate.
 func InitDatabase() *gorm.DB {
-	db, err := gorm.Open(sqlite.Open("yobitsugi.db"), &gorm.Config{})
-	if err != nil {
-		log.Fatal("Failed to connect to database:", err)
-	}
+	var db *gorm.DB
+	var err error
 
-	log.Println("Database connection established.")
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn != "" {
+		log.Println("DATABASE_URL not set, failling back to SQLite.")
+		db, err = gorm.Open(sqlite.Open("yobitsugi.db"), &gorm.Config{})
+		if err != nil {
+			log.Fatal("Failed to connect to SQLite database:", err)
+		}
+		log.Println("SQLite database connection established.")
+	} else {
+		log.Println("DATABASE_URL set, connecting to PostgreSQL...")
+		db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+		if err != nil {
+			log.Fatal("Failed to connect to PostgreSQL database:", err)
+		}
+		log.Println("PostgreSQL database connection established.")
+	}	
 
 	log.Println("Running database auto-migration...")
 	if err := db.AutoMigrate(&AssessmentJob{}); err != nil {

--- a/bff/go.mod
+++ b/bff/go.mod
@@ -3,19 +3,30 @@ module yobitsugi-app/bff
 go 1.23.0
 
 require (
+	github.com/gin-contrib/cors v1.7.6
+	github.com/gin-gonic/gin v1.11.0
+	github.com/gorilla/websocket v1.5.3
+	github.com/joho/godotenv v1.5.1
+	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+)
+
+require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
-	github.com/gin-contrib/cors v1.7.6 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/gin-gonic/gin v1.11.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -40,6 +51,4 @@ require (
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
-	gorm.io/driver/sqlite v1.6.0 // indirect
-	gorm.io/gorm v1.31.1 // indirect
 )

--- a/bff/go.sum
+++ b/bff/go.sum
@@ -31,10 +31,20 @@ github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
@@ -62,6 +72,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -93,6 +104,8 @@ google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
+gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
 gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=

--- a/bff/main.go
+++ b/bff/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
 	"gorm.io/gorm"
 )
 
@@ -239,6 +240,11 @@ func helloHandler(c *gin.Context) {
 }
 
 func main() {
+	// Load environment variables from .env file
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("Error loading .env file, using environment variables.")
+	}
+
 	// Create a default Gin router
 	router := gin.Default()
 


### PR DESCRIPTION
Closes #46

## Description
This PR refactors the database connection to support both PostgreSQL (for production) and SQLite (for local development).

This allows the application to be deployed to services like Fly.io that provide a `DATABASE_URL` environment variable for a PostgreSQL instance, while still allowing easy local development using the `yobitsugi.db` file.

## Acceptance Criteria
-   [x] Installed `gorm.io/driver/postgres` and `github.com/joho/godotenv`.
-   [x] **`database.go` (Modified):**
    -   [x] `InitDatabase()` now checks for the `DATABASE_URL` environment variable.
    -   [x] **If `DATABASE_URL` is present:** It connects to PostgreSQL.
    -   [x] **If `DATABASE_URL` is NOT present:** It falls back to connecting to `yobitsugi.db` (SQLite).
-   [x] **`main.go` (Modified):**
    -   [x] `godotenv.Load()` is called at the beginning of `main()` to load `.env` files for local testing.
-   [x] **Verification:**
    -   [x] Test 1 (Local): Ran `go run .` *without* a `DATABASE_URL` set. Verified the app starts and connects to `yobitsugi.db`.
    -   [x] Test 2 (Prod-Sim): Created a local `.env` file with a valid `DATABASE_URL` (e.g., a local Postgres instance). Verified the app starts and connects to PostgreSQL.
-   [x] Yes, `database.go` is rewritten.
-   [ ] No, this only changes the database connection logic.