### PR TITLE
infra(ci): Add Dockerfile for BFF and local docker-compose environment

### DIFF
--- a/bff/Dockerfile
+++ b/bff/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:1.25-alpine AS builder
-
+FROM golang:1.22-alpine AS builder
 WORKDIR /app
 
 # copy dependencies
@@ -13,7 +12,7 @@ COPY . .
 # create the executable "server"
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server .
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian12
 
 # copy "server"
 COPY --from=stage /app/server /

--- a/bff/Dockerfile
+++ b/bff/Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server .
 FROM gcr.io/distroless/static-debian12
 
 # copy "server"
-COPY --from=stage /app/server /
+COPY --from=builder /app/server /
 
 # Listen the port "8080" for Yobitsugi
 EXPOSE 8080

--- a/bff/Dockerfile
+++ b/bff/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+
+# copy dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# copy source code
+COPY . .
+
+# build the application
+# create the executable "server"
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server .
+
+FROM gcr.io/distroless/static-debian11
+
+# copy "server"
+COPY --from=stage /app/server /
+
+# Listen the port "8080" for Yobitsugi
+EXPOSE 8080
+
+# Execute "server"
+ENTRYPOINT [ "/server" ]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       PYTHON_SERVICE_URL: "http://yobitsugi:8000/assess-kantei" 
       PORT: "8080"
-      DATABASE)RUL: ${DATABASE_URL}
+      DATABASE_URL: ${DATABASE_URL}
     depends_on:
       - yobitsugi
       - db
@@ -36,18 +36,18 @@ services:
     volumes:
       - ../yobitsugi/data/corpus:/data/corpus:ro
 
-    # 3. PostgreSQL Database
-    db:
-      image: postgres:15-alpine
-      restart: always
-      environment:
-        POSTGRES_USER: ${POSTGRES_USER}
-        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-        POSTGRES_DB: ${POSTGRES_DB}
-      ports:
-        - "5432:5432"
-      volumes:
-        - postgres_data:/var/lib/postgresql/data
+  # 3. PostgreSQL Database
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  # 1. Go BFF 
+  bff:
+    build:
+      context: ./bff
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./.env 
+    environment:
+      PYTHON_SERVICE_URL: "http://yobitsugi:8000/assess-kantei" 
+      PORT: "8080"
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID}
+    depends_on:
+      - yobitsugi
+
+  # 2. Python Yobitsugi (External Repository)
+  yobitsugi:
+    build:
+      context: ../Yobitsugi
+      dockerfile: api/Dockerfile 
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./.env
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY}
+
+      CORPUS_DIR: /data/corpus
+      RANKING_MODEL_PATH: /data/corpus/ranking_model.joblib
+      PROMPTS_DIR: /app/api_prompts
+    volumes:
+      - ../Yobitsugi/data/corpus:/data/corpus:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
     environment:
       PYTHON_SERVICE_URL: "http://yobitsugi:8000/assess-kantei" 
       PORT: "8080"
-      GCP_PROJECT_ID: ${GCP_PROJECT_ID}
+      DATABASE)RUL: ${DATABASE_URL}
     depends_on:
       - yobitsugi
+      - db
 
   # 2. Python Yobitsugi (External Repository)
   yobitsugi:
@@ -34,3 +35,19 @@ services:
       RANKING_MODEL_PATH: /data/corpus/ranking_model.joblib
     volumes:
       - ../yobitsugi/data/corpus:/data/corpus:ro
+
+    # 3. PostgreSQL Database
+    db:
+      image: postgres:15-alpine
+      restart: always
+      environment:
+        POSTGRES_USER: ${POSTGRES_USER}
+        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+        POSTGRES_DB: ${POSTGRES_DB}
+      ports:
+        - "5432:5432"
+      volumes:
+        - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,5 @@ services:
 
       CORPUS_DIR: /data/corpus
       RANKING_MODEL_PATH: /data/corpus/ranking_model.joblib
-      PROMPTS_DIR: /app/api_prompts
     volumes:
-      - ../Yobitsugi/data/corpus:/data/corpus:ro
+      - ../yobitsugi/data/corpus:/data/corpus:ro


### PR DESCRIPTION
Closes #44

## Description
This PR containerizes the Go BFF service by adding a `bff/Dockerfile`. This is a mandatory step for deploying to container-based hosts like Fly.io or Google Cloud Run.

This PR also adds a `docker-compose.yml` file to the repository root. This file creates a complete, production-like local testing environment by building and running all three services together: `bff` (Go), `yobitsugi` (Python), and `db` (Postgres).

## Acceptance Criteria
-   [x] Create a `Dockerfile` in the `bff/` directory for the Go application (using a multi-stage build is recommended for a small image).
-   [x] Create a `Dockerfile` in the `yobitsugi-kantei` (Python) repository.
-   [x] (Optional but recommended) Create a `docker-compose.yml` file in the `yobitsugi-app` root to test the *entire* stack (React + Go + Python) locally using Docker.
-   [x] Ensure `go run .` is replaced with the containerized service in `docker-compose`.
-   [x] Yes, two new `Dockerfile`s are created.
-   [x] No, this only prepares the services for deployment.
